### PR TITLE
docs: HW-integration: more info about power on sequence

### DIFF
--- a/docs/hardware-integration/power_on_sequence.md
+++ b/docs/hardware-integration/power_on_sequence.md
@@ -1,3 +1,4 @@
+Neutis module has an internal delay(Trst), it is important for the correct power-on process.
 Power-on reset signal gets propagated
 to CPU 60 ms after 3V3_IN power becomes stable. The diagram below shows that voltage at all
 power inputs becomes stable at the same time or with delays (t1, t2) no more


### PR DESCRIPTION
Add a little more info about power on sequence: Neutis has an internal delay(~60 ms)